### PR TITLE
Avoid fatal errors when the BP Legacy Template Pack is active

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -12,8 +12,24 @@
 define( 'BUDDYX_MINIMUM_WP_VERSION', '4.5' );
 define( 'BUDDYX_MINIMUM_PHP_VERSION', '7.0' );
 
+/**
+ * Checks if the BP Template pack is Nouveau when BuddyPress is active.
+ *
+ * @return boolean False if BuddyPress is not active or Nouveau is the active Template Pack.
+ *                 True otherwise.
+ */
+function buddyx_template_pack_check() {
+	$retval = false;
+
+	if ( function_exists( 'buddypress' ) ) {
+		$retval = 'nouveau' !== bp_get_theme_compat_id();
+	}
+
+	return $retval;
+}
+
 // Bail if requirements are not met.
-if ( version_compare( $GLOBALS['wp_version'], BUDDYX_MINIMUM_WP_VERSION, '<' ) || version_compare( phpversion(), BUDDYX_MINIMUM_PHP_VERSION, '<' ) ) {
+if ( version_compare( $GLOBALS['wp_version'], BUDDYX_MINIMUM_WP_VERSION, '<' ) || version_compare( phpversion(), BUDDYX_MINIMUM_PHP_VERSION, '<' ) || buddyx_template_pack_check() ) {
 	require get_template_directory() . '/inc/back-compat.php';
 	return;
 }

--- a/inc/back-compat.php
+++ b/inc/back-compat.php
@@ -35,6 +35,10 @@ function buddyx_get_insufficient_requirements_message() {
 		return sprintf( __( 'Buddyx requires at least PHP version %1$s. You are running version %2$s. Please update and try again.', 'buddyx' ), BUDDYX_MINIMUM_PHP_VERSION, phpversion() );
 	}
 
+	if ( buddyx_template_pack_check() ) {
+		return __( 'Buddyx requires the BuddyPress Template Pack "BP Nouveau" to be active. Please activate this Template Pack from the BuddyPress Options.', 'buddyx' );
+	}
+
 	return '';
 }
 


### PR DESCRIPTION
If the BP Legacy Template Pack is active, as you are using BP Nouveau specific functions into your code, then you get fatal errors when trying to access to a BuddyPress area.